### PR TITLE
Add definitions for Max & Min date range.

### DIFF
--- a/types/cleave.js/options/index.d.ts
+++ b/types/cleave.js/options/index.d.ts
@@ -16,6 +16,8 @@ export interface CleaveOptions {
 // Date Options
 export interface CleaveOptions {
     date?: boolean;
+    dateMin?: string;
+    dateMax?: string;
     datePattern?: ReadonlyArray<string>;
 }
 


### PR DESCRIPTION
Add definitions for Max & Min date range added in cleave.js v.1.5.0.

https://github.com/nosir/cleave.js/blob/master/doc/options.md
